### PR TITLE
Move Tekton back to Pipeline Orchestration

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -80,6 +80,14 @@ landscape:
             logo: spinnaker.svg
             twitter: https://twitter.com/spinnakerio
             crunchbase: https://www.crunchbase.com/organization/continuous-delivery-foundation-cdf
+          - item:
+            name: Tekton Pipelines
+            homepage_url: https://tekton.dev/
+            project: graduated
+            repo_url: https://github.com/tektoncd/pipeline
+            logo: tekton.svg
+            twitter: https://twitter.com/tektoncd
+            crunchbase: https://www.crunchbase.com/organization/continuous-delivery-foundation-cdf
       - subcategory:
         name: Continuous Integration
         items:
@@ -96,14 +104,6 @@ landscape:
             repo_url: https://github.com/jenkinsci/jenkins
             logo: jenkins.svg
             twitter: https://twitter.com/jenkinsci
-            crunchbase: https://www.crunchbase.com/organization/continuous-delivery-foundation-cdf
-          - item:
-            name: Tekton Pipelines
-            homepage_url: https://tekton.dev/
-            project: graduated
-            repo_url: https://github.com/tektoncd/pipeline
-            logo: tekton.svg
-            twitter: https://twitter.com/tektoncd
             crunchbase: https://www.crunchbase.com/organization/continuous-delivery-foundation-cdf
           - item:
             name: Travis CI


### PR DESCRIPTION
Tekton was moved to CI in #27 but Tekton owners believe it belongs in Pipeline Orchestration

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [y] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [y] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [y] Have you picked the single best (existing) category for your project?
* [y] Does it follow the other guidelines from the [new entries](https://github.com/cdfoundation/cdf-landscape#new-entries) section?
* [y] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [y] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cdfoundation/cdf-landscape#logos)?
* [y] Does your project/product name match the text on the logo?
* [n] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [not yet] ~5 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
