### PR TITLE
docs: fix CDF Code of Conduct link

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-We follow the [CDF Code of Conduct](https://github.com/cdfoundation/toc/blob/master/CODE_OF_CONDUCT.md).
+We follow the [CDF Code of Conduct](https://github.com/cdfoundation/.github/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Code of Conduct page is now in [cdfoundation/.github](https://github.com/cdfoundation/.github) repo.