### PR TITLE
Add Cloudsmith to the CD Landscape map

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -389,6 +389,11 @@ landscape:
             logo: fossa.svg
             crunchbase: https://www.crunchbase.com/organization/fossa-2
           - item:
+            name: Cloudsmith
+            homepage_url: https://cloudsmith.com
+            logo: cloudsmith-member.svg
+            crunchbase: https://www.crunchbase.com/organization/cloudsmith-io           
+          - item:
             name: JFrog Artifactory
             homepage_url: https://jfrog.com/artifactory/
             logo: jfrog.svg


### PR DESCRIPTION
Cloudsmith is a member logo in this Github repository but is not listed in the same group as JFrog and Sonatype. Updating that with this PR: https://github.com/cdfoundation/cdf-landscape/blob/main/cached_logos/cloudsmith-member.svg

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Does it follow the guidelines for [new entries](https://github.com/cdfoundation/cdf-landscape#new-entries)?
* [x] Have you added an SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow logo [guidelines](https://github.com/cdfoundation/cdf-landscape#logos)?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~5 minutes after opening the pull request, the CNCF-Bot will post a link for you to preview your changes. Have you confirmed that they are correct and then added a comment to the PR saying "LGTM"?
